### PR TITLE
Add package dependencies

### DIFF
--- a/company-ghc.el
+++ b/company-ghc.el
@@ -5,6 +5,7 @@
 ;; Author:    Iku Iwasa <iku.iwasa@gmail.com>
 ;; URL:       http://github.com/iquiw/company-ghc
 ;; Version:   0.0.0
+;; Package-Requires: ((cl-lib "0.5") (company "0.8.0") (ghc "4.1.1") (emacs "24.4"))
 ;; Keywords:  haskell, completion
 ;; Stability: unstable
 


### PR DESCRIPTION
I plan to add this package to MELPA and MELPA Stable, so these dependencies are required. Note that the emacs "24.4" dependency is due to your use of `cl-case`: if you can replace that with something more traditional (and remove `lexical-binding: t`), then the code would probably work fine with Emacs 23 and older 24.x releases, which I think would be a good idea.
