### PR TITLE
Operator support in candidates

### DIFF
--- a/features/candidates.feature
+++ b/features/candidates.feature
@@ -212,6 +212,7 @@ Feature: company-ghc candidates
     Given these module keywords:
       | module          | keywords                               |
       | Predule         | head readFile splitAt tail writeFile   |
+      | Control.Monad   | >> >>= =<< return fail                 |
       | Data.Text       | Text singleton splitOn strip           |
       | Data.Text.IO    | readFile writeFile                     |
       | Data.ByteString | ByteString singleton splitAt           |
@@ -270,6 +271,21 @@ Feature: company-ghc candidates
     """
     And I execute company-ghc candidates command at current point
     Then company-ghc candidates are "("readFile")"
+
+    When I insert:
+    """
+    )
+    import Control.Monad hiding ((
+    """
+    And I execute company-ghc candidates command at current point
+    Then company-ghc candidates are "(">>" ">>=" "=<<")"
+
+    When I insert:
+    """
+    >>), return, (>
+    """
+    And I execute company-ghc candidates command at current point
+    Then company-ghc candidates are "(">>" ">>=")"
 
   Scenario: Loaded modules keyword candidates
     Given the buffer is empty

--- a/features/prefix.feature
+++ b/features/prefix.feature
@@ -149,10 +149,18 @@ Feature: company-ghc prefix
     When I insert:
     """
     import safe qualified "package" Some.Module ( SomeVar
-                                                  , AnotherVar
+                                                , AnotherVar
     """
     And I execute company-ghc prefix command at current point
     Then company-ghc prefix is "AnotherVar"
+
+    Given the buffer is empty
+    When I insert:
+    """
+    import Some.Module (SomeVar, (=$
+    """
+    And I execute company-ghc prefix command at current point
+    Then company-ghc prefix is "=$"
 
   Scenario: Keyword prefix
     Given the buffer is empty


### PR DESCRIPTION
using "-o" option of ghc-mod's browse command.

fixes #19