### PR TITLE
fix company-ghc-doc-buffer

### DIFF
--- a/company-ghc.el
+++ b/company-ghc.el
@@ -209,7 +209,8 @@ If enabled, \"C.M\" to match with module \"Control.Monad\", etc."
   "Display documentation in the docbuffer for the given CANDIDATE."
   (with-temp-buffer
     (let* ((mod (company-ghc--pget candidate :module))
-          (command (concat company-ghc-hoogle-command " --info " (if mod (concat candidate " +" mod) candidate))))
+           (searchExpr (shell-quote-argument (if mod (concat candidate " +" mod) candidate)))
+           (command (concat company-ghc-hoogle-command " --info " searchExpr)))
       (call-process-shell-command command nil t nil))
     (company-doc-buffer
      (buffer-substring-no-properties (point-min) (point-max)))))

--- a/company-ghc.el
+++ b/company-ghc.el
@@ -208,9 +208,9 @@ If enabled, \"C.M\" to match with module \"Control.Monad\", etc."
 (defun company-ghc-doc-buffer (candidate)
   "Display documentation in the docbuffer for the given CANDIDATE."
   (with-temp-buffer
-    (let ((mod (company-ghc--pget candidate :module)))
-      (call-process company-ghc-hoogle-command nil t nil "search" "--info"
-                    (if mod (concat candidate " +" mod) candidate)))
+    (let* ((mod (company-ghc--pget candidate :module))
+          (command (concat company-ghc-hoogle-command " --info " (if mod (concat candidate " +" mod) candidate))))
+      (call-process-shell-command command nil t nil))
     (company-doc-buffer
      (buffer-substring-no-properties (point-min) (point-max)))))
 

--- a/company-ghc.el
+++ b/company-ghc.el
@@ -209,8 +209,8 @@ If enabled, \"C.M\" to match with module \"Control.Monad\", etc."
   "Display documentation in the docbuffer for the given CANDIDATE."
   (with-temp-buffer
     (let* ((mod (company-ghc--pget candidate :module))
-           (searchExpr (shell-quote-argument (if mod (concat candidate " +" mod) candidate)))
-           (command (concat company-ghc-hoogle-command " --info " searchExpr)))
+           (search-expr (shell-quote-argument (if mod (concat candidate " +" mod) candidate)))
+           (command (concat company-ghc-hoogle-command " --info " search-expr)))
       (call-process-shell-command command nil t nil))
     (company-doc-buffer
      (buffer-substring-no-properties (point-min) (point-max)))))


### PR DESCRIPTION
fix it so that it works with haskell-hoogle-command that is
actually a command and not just an executable name